### PR TITLE
17 feat seperate fetch on aktuellt page for images

### DIFF
--- a/app/aktuellt/page.tsx
+++ b/app/aktuellt/page.tsx
@@ -2,32 +2,26 @@ import { renderRichText } from "@/lib/contentful/rich-text";
 
 import { notFound } from "next/navigation";
 import Image from "next/image";
-import { getLatest, getLatest2 } from "@/lib/contentful/latest/api";
-import { fetchAssets } from "@/lib/contentful/api";
+import { getLatest } from "@/lib/contentful/latest/api";
 
 export default async function LatestPage() {
   const latest = await getLatest();
-  const latest2 = await getLatest2();
-/*   const assets = await fetchAssets() */
-  console.log("getLatest2", latest2);
-  
-  
-/*   console.log("assets", assets); */
+
+
   
   if(!latest) return notFound();
   return (
     <main className=" content-grid">
       <ul className="popout mt-45 lg:mt-50 xl:mt-60 flex flex-col gap-20">
         {latest.length &&
-        //ask about help in fetch so I don't have to set any here
-          latest.map((item:any) => {
+          latest.map((item) => {
             return (
               <li key={item.id} className=" md:text-2xl 2xl:text-3xl text-white">
                 <Image
-                  src={`https:${item?.image?.fields?.file?.url}`}
-                  height={item?.image?.fields?.file?.details?.image?.height}
-                  width={item?.image?.fields?.file?.details?.image?.width}
-                  alt={item?.image?.fields?.title ?? ""}
+                  src={`https:${item.image?.url}`}
+                  height={item?.image?.dimensions?.height}
+                  width={item?.image?.dimensions?.width}
+                  alt={item?.image?.description?? ""}
                   ></Image>
                   {renderRichText(item.body)}
               </li>

--- a/lib/contentful/api.ts
+++ b/lib/contentful/api.ts
@@ -1,7 +1,5 @@
 import { Entry, EntrySkeletonType } from "contentful";
 import { client } from "./client";
-/*  const space = process.env.CONTENTFUL_SPACE_ID;
-  const accessToken = process.env.CONTENTFUL_ACCESS_TOKEN; */
 
 export async function fetchEntries<T extends EntrySkeletonType>(
   contentType: T["contentTypeId"]
@@ -13,23 +11,16 @@ export async function fetchEntries<T extends EntrySkeletonType>(
   return response.items;
 }
 
-export async function fetchEntries2(contentType) {
-  const response = await client.getEntries({
-    limit: 4,
-    content_type: contentType,
-/*     select: ["sys.id","fields.image"] */
-/*     include:3 */
-  /*    select: ["fields"] */
+export async function fetchImageAssets<T extends EntrySkeletonType>(contentType: T["contentTypeId"]) {
+  const response = await client.getAssets(contentType);
+
+  return response.items.map((item) => {
+    const url = item.fields.file?.url;
+    const description = item.fields.description;
+    const dimensions = item.fields.file?.details.image;
+    const id = item.sys.id;
+    const title = item.fields.title
+    const image = {url,description, dimensions, id, title}
+    return image;
   });
-  return response.items;
-}
-/* export async function fetchEntriesByUrl(contentType) {
-  const response = await fetch(`/spaces/${space}/environments/master/entries/?access_token=${accessToken}&content_type=${contentType}&select=sys.id,fields.body`
-)
-return response.items;
-} */
-//to be implemented
-export async function fetchAssets() {
-  const response = await client.getAssets("newsItem");
-  return response.items;
 }

--- a/lib/contentful/latest/api.ts
+++ b/lib/contentful/latest/api.ts
@@ -1,31 +1,16 @@
-import { fetchEntries, fetchEntries2, fetchEntriesByUrl } from "../api";
-import { client } from "../client";
-import { TypeNewsItem,TypeNewsItemSkeleton} from "./types";
-
-//this is not used right now, delete if not needed
-export async function fetchNewsItems(): Promise<TypeNewsItem<never, 'sv-SE'>[]> {
-  const response = await client.getEntries<TypeNewsItemSkeleton>({
-    content_type: "newsItem",
-
-
-  });
-  return response.items
-}
+import { fetchEntries, fetchImageAssets } from '../api';
+import { TypeNewsItemSkeleton } from './types';
+import { type Document as CfDocument,
+} from '@contentful/rich-text-types';
 
 export async function getLatest() {
-  const response = await fetchEntries<TypeNewsItemSkeleton>("newsItem");
-  return response.map((item) => {
-    const image = item.fields.image;
+  const entriesResponse = await fetchEntries<TypeNewsItemSkeleton>('newsItem');
+  const assetImages = await fetchImageAssets<TypeNewsItemSkeleton>('newsItem');
+  return entriesResponse.map((item) => {
+    const image = assetImages.find(asset => asset.id === item.sys.id)
     const id = item.sys.id;
-    const body = item.fields.body
+    const body = item.fields.body as CfDocument;
 
-    return { image, id, body}
-  })
-  
-
-
-} 
-export async function getLatest2() {
-  const response = await fetchEntries2("newsItem");
-  return response;
-} 
+    return { image, id, body };
+  });
+}

--- a/lib/contentful/latest/types.ts
+++ b/lib/contentful/latest/types.ts
@@ -1,4 +1,4 @@
-import type { Asset, ChainModifiers, Entry, EntryFieldTypes, EntrySkeletonType, LocaleCode } from "contentful";
+import type {  ChainModifiers, Entry, EntryFieldTypes, EntrySkeletonType, LocaleCode } from "contentful";
 
 import { CFImageFile } from '../types';
 import type { Document as CfDocument } from '@contentful/rich-text-types';
@@ -12,7 +12,7 @@ export type TransformedNewsItem = {
 export interface TypeNewsItemFields {
     title?: EntryFieldTypes.Symbol;
     body?: EntryFieldTypes.RichText;
-    image?: Asset;
+    image?: EntryFieldTypes.AssetLink;
     date?: EntryFieldTypes.Date;
     link?: EntryFieldTypes.Symbol;
     linkText?: EntryFieldTypes.Symbol;
@@ -20,28 +20,3 @@ export interface TypeNewsItemFields {
 
 export type TypeNewsItemSkeleton = EntrySkeletonType<TypeNewsItemFields, "newsItem">;
 export type TypeNewsItem<Modifiers extends ChainModifiers, Locales extends LocaleCode = LocaleCode> = Entry<TypeNewsItemSkeleton, Modifiers, Locales>;
-
-export type manuallyCreatedNewsItemType = {
-  sys: {
-    id: string;
-  }
-  fields: {
-    title: string;
-    body: EntryFieldTypes.RichText;
-    image: {
-      fields: {
-        file: {
-          details: {
-            image: {
-              width: number;
-              height: number;
-            }
-          }
-          filename: string;
-          url: string;
-        }
-      }
-    }
-
-  }
-}


### PR DESCRIPTION
Fetch assets for newsItems and combine the response with the entries response for newsItem in order to have more control over the return type and make the newsItem more shallow before populating the "aktuellt" page 